### PR TITLE
Change hash router branch

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,9 +4,10 @@ import { initializeApp } from "@firebase/app";
 import { getAuth, onAuthStateChanged, User } from "firebase/auth";
 import React from "react";
 import Signin from "./components/Signin";
-import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
+import { BrowserRouter as Switch, Route, HashRouter } from "react-router-dom";
 import Signup from "./components/Signup";
 import { Dashboard } from "./components/Dashboard/Dashboard";
+// import { Hash } from "crypto";
 
 export const app = initializeApp(appConfig);
 export const auth = getAuth(app);
@@ -29,7 +30,7 @@ function App() {
 
   return (
     <div>
-      <Router>
+      <HashRouter>
         <CurrentUserContext.Provider value={currentUser}>
           <Switch>
             <Route exact path="/signin" component={Signin} />
@@ -37,7 +38,7 @@ function App() {
             <Route exact path="/dashboard" component={Dashboard} />
           </Switch>
         </CurrentUserContext.Provider>
-      </Router>
+      </HashRouter>
     </div>
   );
 }

--- a/src/components/Dashboard/EventForm.tsx
+++ b/src/components/Dashboard/EventForm.tsx
@@ -40,7 +40,7 @@ export default function EventForm() {
 
       const redirect = await response.text();
       console.log(redirect);
-      window.location.href = redirect;
+      window.location.href = `https://obscure-river-76343.herokuapp.com/${redirect}`;
     } catch (err) {
       console.error(err.message);
     }

--- a/src/components/Dashboard/EventForm.tsx
+++ b/src/components/Dashboard/EventForm.tsx
@@ -39,9 +39,8 @@ export default function EventForm() {
       );
 
       const redirect = await response.text();
-      console.log(redirect)
+      console.log(redirect);
       window.location.href = redirect;
-      
     } catch (err) {
       console.error(err.message);
     }

--- a/src/components/Dashboard/EventForm.tsx
+++ b/src/components/Dashboard/EventForm.tsx
@@ -38,8 +38,10 @@ export default function EventForm() {
         }
       );
 
-      window.location.href = "/dashboard";
-      console.log(response);
+      const redirect = await response.text();
+      console.log(redirect)
+      window.location.href = redirect;
+      
     } catch (err) {
       console.error(err.message);
     }


### PR DESCRIPTION
Changed browser router to hash router. 

May need to download browser history if you use reload anywhere

https://reactrouter.com/web/api/HashRouter - 

"_IMPORTANT NOTE: Hash history does not support location.key or location.state. In previous versions we attempted to shim the behavior but there were edge-cases we couldn’t solve. Any code or plugin that needs this behavior won’t work. As this technique is only intended to support legacy browsers, we encourage you to configure your server to work with <BrowserHistory> instead._"